### PR TITLE
Feat(highlight) for expression 语法高亮

### DIFF
--- a/res/wxml.language-configuration.json
+++ b/res/wxml.language-configuration.json
@@ -12,9 +12,10 @@
 		{ "open": "{", "close": "}"},
 		{ "open": "[", "close": "]"},
 		{ "open": "(", "close": ")" },
-		{ "open": "'", "close": "'" },
-		{ "open": "\"", "close": "\"" }
+		{ "open": "'", "close": "'" , "notIn": ["string"] },
+		{ "open": "\"", "close": "\"" , "notIn": ["string"] }
 	],
+	"autoCloseBefore": "\"'-_:<>.,=}# \t\n",
 	"surroundingPairs": [
 		{ "open": "'", "close": "'" },
 		{ "open": "\"", "close": "\"" },

--- a/res/wxml.tmLanguage.json
+++ b/res/wxml.tmLanguage.json
@@ -189,7 +189,7 @@
           "end": "\\}\\}\\}?",
           "patterns": [
             {
-              "include": "source.js"
+              "include": "source.js#expression"
             }
           ],
           "beginCaptures": {

--- a/res/wxml.tmLanguage.json
+++ b/res/wxml.tmLanguage.json
@@ -163,6 +163,7 @@
       "patterns": [
         {
           "name": "source.directive.wxml",
+          "contentName": "support.function.wxml",
           "begin": "([\"'])",
           "beginCaptures": {
             "1": {
@@ -174,19 +175,15 @@
             "0": {
               "name": "string.quoted.end.html"
             }
-          },
-          "patterns": [
-            {
-              "include": "source.js"
-            }
-          ]
+          }
         }
       ]
     },
     "wxml-interpolations": {
       "patterns": [
         {
-          "end": "\\}\\}\\}?",
+          "contentName": "markup.blob markup.heading",
+          "end": "\\}\\}",
           "patterns": [
             {
               "include": "source.js#expression"
@@ -194,14 +191,14 @@
           ],
           "beginCaptures": {
             "0": {
-              "name": "punctuation.definition.generic.begin.html"
+              "name": "support.constant.handlebars.wxml"
             }
           },
           "name": "expression.embedded.wxml",
-          "begin": "\\{\\{\\{?",
+          "begin": "\\{\\{",
           "endCaptures": {
             "0": {
-              "name": "punctuation.definition.generic.end.html"
+              "name": "support.constant.handlebars.wxml"
             }
           }
         }
@@ -371,7 +368,6 @@
         }
       }
     },
-
     {
       "end": "(<?/)(wxs)?(>)",
       "begin": "(<)(wxs)",
@@ -414,7 +410,6 @@
         }
       ]
     },
-
     {
       "end": "(</)(template)(>)",
       "begin": "(<)(template)",

--- a/src/plugin/AutoCompletion.ts
+++ b/src/plugin/AutoCompletion.ts
@@ -22,6 +22,7 @@ import { getTagAtPosition } from './getTagAtPosition/'
 import * as s from './res/snippets'
 import { getClass } from './lib/StyleFile'
 import { getCloseTag } from './lib/closeTag'
+import { getProp } from './lib/ScriptFile'
 
 export default abstract class AutoCompletion {
   abstract id: 'wxml' | 'wxml-pug'
@@ -181,27 +182,37 @@ export default abstract class AutoCompletion {
     if (!tag) return []
     if (tag.isOnTagName) {
       return this.createComponentSnippetItems(lc, doc, pos, tag.name)
-    } else if (tag.isOnAttrValue && tag.attrName) {
+    }
+    if (tag.isOnAttrValue && tag.attrName) {
       let attrValue = tag.attrs[tag.attrName]
       if (tag.attrName === 'class') {
         let existsClass = (tag.attrs.class || '') as string
         return this.autoCompleteClassNames(doc, existsClass ? existsClass.trim().split(/\s+/) : [])
-      } else if (typeof attrValue === 'string' && attrValue.trim() === '') {
-        let values = await autocompleteTagAttrValue(tag.name, tag.attrName, lc, this.getCustomOptions(doc))
-        if (!values.length) return []
-        let range = doc.getWordRangeAtPosition(pos, /['"]\s*['"]/)
-        if (range) {
-          range = new Range(
-            new Position(range.start.line, range.start.character + 1),
-            new Position(range.end.line, range.end.character - 1)
-          )
+      } else if (typeof attrValue === 'string') {
+        if ((tag.attrName.startsWith('bind') || tag.attrName.startsWith('catch'))) {
+          // 函数自动补全
+          return this.autoCompleteMethods(doc, attrValue.replace(/"|'/, ''))
+        } else if (attrValue.trim() === '') {
+          let values = await autocompleteTagAttrValue(tag.name, tag.attrName, lc, this.getCustomOptions(doc))
+          if (!values.length) return []
+          let range = doc.getWordRangeAtPosition(pos, /['"]\s*['"]/)
+          if (range) {
+            range = new Range(
+              new Position(range.start.line, range.start.character + 1),
+              new Position(range.end.line, range.end.character - 1)
+            )
+          }
+          return values.map(v => {
+            let it = new CompletionItem(v.value, CompletionItemKind.Value)
+            it.documentation = new MarkdownString(v.markdown)
+            it.range = range
+            return it
+          })
         }
-        return values.map(v => {
-          let it = new CompletionItem(v.value, CompletionItemKind.Value)
-          it.documentation = new MarkdownString(v.markdown)
-          it.range = range
-          return it
-        })
+
+        // } else if ((tag.attrName.startsWith('bind') || tag.attrName.startsWith('catch')) && typeof attrValue === 'string') {
+
+        //   return this.autoCompleteMethods(doc, attrValue.replace(/"|'/, ''))
       }
       return []
     } else {
@@ -304,7 +315,7 @@ export default abstract class AutoCompletion {
   /**
    * 闭合标签自动完成
    * @param doc
-   * @param pos
+   * @param pos 
    */
   async createCloseTagCompletionItem(doc: TextDocument, pos: Position): Promise<CompletionItem[]> {
     const text = doc.getText(new Range(new Position(0, 0), pos))
@@ -328,6 +339,57 @@ export default abstract class AutoCompletion {
     return []
   }
 
+  /**
+   * 函数自动提示
+   * @param doc
+   * @param prefix 函数前缀,空则查找所有函数
+   */
+  autoCompleteMethods(doc: TextDocument, prefix: string): CompletionItem[] {
+    /**
+     * 页面周期和组件 生命周期函数,
+     * 显示时置于最后
+     * 列表中顺序决定显示顺序
+     */
+    const lowPriority = [
+      'onPullDownRefresh', 'onReachBottom', 'onPageScroll',
+      'onShow', 'onHide', 'onTabItemTap', 'onLoad', 'onReady', 'onResize', 'onUnload', 'onShareAppMessage',
+      'error', 'creaeted', 'attached', 'ready', 'moved', 'detached', 'observer',
+    ]
+    const methods = getProp(doc.uri.fsPath, 'method', (prefix || '[\\w_$]') + '[\\w\\d_$]*')
+    const root = getRoot(doc)
+    return methods.map(l => {
+      const c = new CompletionItem(l.name, getMethodKind(l.detail))
+      const filePath = root ? path.relative(root, l.loc.uri.fsPath) : path.basename(l.loc.uri.fsPath)
+      // 低优先级排序滞后
+      const priotity = lowPriority.indexOf(l.name) + 1
+      c.detail = `${filePath}\n[${l.loc.range.start.line}行,${l.loc.range.start.character}列]`
+      c.documentation = new MarkdownString('```ts\n' + l.detail + '\n```')
+      /**
+       * 排序显示规则
+       * 1. 正常函数 如 `onTap`
+       * 2. 下划线函数 `_save`
+       * 3. 生命周期函数 `_onShow`
+       */
+      if (priotity > 0) {
+        c.detail += '(生命周期函数)'
+        c.kind = CompletionItemKind.Field
+        c.sortText = '}'.repeat(priotity)
+      } else {
+        c.sortText = l.name.replace('_', '{')
+      }
+      return c
+    })
+  }
+
+}
+
+/**
+ * 是否为属性式函数声明
+ * 如 属性式声明 `foo:()=>{}`
+ * @param text
+ */
+function getMethodKind(text: string) {
+  return /^\s*[\w_$][\w_$\d]*\s*:/.test(text) ? CompletionItemKind.Property : CompletionItemKind.Method;
 }
 
 function autoSuggestCommand() {

--- a/src/plugin/AutoCompletion.ts
+++ b/src/plugin/AutoCompletion.ts
@@ -315,7 +315,7 @@ export default abstract class AutoCompletion {
   /**
    * 闭合标签自动完成
    * @param doc
-   * @param pos 
+   * @param pos
    */
   async createCloseTagCompletionItem(doc: TextDocument, pos: Position): Promise<CompletionItem[]> {
     const text = doc.getText(new Range(new Position(0, 0), pos))
@@ -368,7 +368,7 @@ export default abstract class AutoCompletion {
        * 排序显示规则
        * 1. 正常函数 如 `onTap`
        * 2. 下划线函数 `_save`
-       * 3. 生命周期函数 `_onShow`
+       * 3. 生命周期函数 `onShow`
        */
       if (priotity > 0) {
         c.detail += '(生命周期函数)'
@@ -389,7 +389,7 @@ export default abstract class AutoCompletion {
  * @param text
  */
 function getMethodKind(text: string) {
-  return /^\s*[\w_$][\w_$\d]*\s*:/.test(text) ? CompletionItemKind.Property : CompletionItemKind.Method;
+  return /^\s*[\w_$][\w_$\d]*\s*:/.test(text) ? CompletionItemKind.Property : CompletionItemKind.Method
 }
 
 function autoSuggestCommand() {

--- a/src/plugin/PropDefinitionProvider.ts
+++ b/src/plugin/PropDefinitionProvider.ts
@@ -1,5 +1,5 @@
 import { Config } from './lib/config'
-import {DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri, Range} from 'vscode'
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri, Range } from 'vscode'
 import { getTagAtPosition } from './getTagAtPosition'
 import { getClass } from './lib/StyleFile'
 import { getProp } from './lib/ScriptFile'
@@ -9,13 +9,13 @@ const reserveWords = [
 ]
 
 export class PropDefinitionProvider implements DefinitionProvider {
-  constructor(public config: Config) {}
+  constructor(public config: Config) { }
   public async provideDefinition(document: TextDocument, position: Position, token: CancellationToken) {
     const tag = getTagAtPosition(document, position)
     const locs: Location[] = []
 
     if (tag) {
-      const {attrs, attrName, posWord} = tag
+      const { attrs, attrName, posWord } = tag
       const rawAttrValue = ((attrs['__' + attrName] || '') as string).replace(/^['"]|['"]$/g, '') // 去除引号
 
       // 不在属性上
@@ -42,7 +42,7 @@ export class PropDefinitionProvider implements DefinitionProvider {
   }
 
   searchScript(type: 'prop' | 'method', word: string, doc: TextDocument) {
-    return getProp(doc.fileName, type, word)
+    return getProp(doc.fileName, type, word).map(p => p.loc)
   }
 
   searchStyle(className: string, document: TextDocument, position: Position) {


### PR DESCRIPTION
* 高亮表达式和命名 参考 [handlebars](https://github.com/microsoft/vscode/tree/master/extensions/handlebars/syntaxes) 
* 绑定函数高亮显示
* 修正 `{{{a}}}` 语法解析 原来 `a` →`{a}` 

## 在 `disableDecorate` 情况下的显示情况

* vscode 默认主题(dark+ theme):
![image](https://user-images.githubusercontent.com/6290356/60041549-48d7dd00-96ee-11e9-834c-ff9f4900683e.png)
* vscode 默认亮主题(light+ theme):
![image](https://user-images.githubusercontent.com/6290356/60041837-e0d5c680-96ee-11e9-995c-e8fef7097c7f.png)
* 自带monokai主题
![image](https://user-images.githubusercontent.com/6290356/60041664-8ccae200-96ee-11e9-8e0d-987cac168b3b.png)

颜色由主题设置

语法命名参考
* https://macromates.com/manual/en/language_grammars#naming_conventions
* https://github.com/microsoft/vscode/tree/master/extensions