### PR TITLE
feat: support underscore in tag

### DIFF
--- a/syntaxes/wxml.tmLanguage.json
+++ b/syntaxes/wxml.tmLanguage.json
@@ -538,7 +538,7 @@
         }
       },
       "name": "meta.tag.other.html",
-      "begin": "(</?)([a-zA-Z0-9:-]+)",
+      "begin": "(</?)([a-zA-Z0-9:\\-\\_]+)",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.tag.end.html"


### PR DESCRIPTION
<!-- 非常感谢你的PR，请花一点时间填一下下面的问题 -->

**解决了什么问题**: 在tag name当中支持高亮下划线
<img width="253" alt="image" src="https://github.com/wx-minapp/minapp-vscode/assets/1147375/2b6d48bd-f97e-4569-98ba-a6b6a4d5b5e5">
如图所示，这个 `map_card` 没有正确高亮。但实际上程序可以正常运行，并且根据 https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/ ，下划线是合法的。
<img width="474" alt="image" src="https://github.com/wx-minapp/minapp-vscode/assets/1147375/2be8d4ac-aa68-4380-9455-29ce7789d4b4">




**代码如何实现**: 改了tag语法的正则表达式


**检查清单**:


<!--
  确认已完成的请在[ ]中写入字符x
  例子:
    - [x] 本地测试通过
-->
- [ ] 本地测试通过
- [ ] 可以正常build出vsix文件
- [ ] 更新文档Readme和ChangeLog
