### PR TITLE
fix: solve the problem of not being able to format wxml with Prettier

### DIFF
--- a/src/plugin/WxmlFormatter.ts
+++ b/src/plugin/WxmlFormatter.ts
@@ -56,7 +56,7 @@ export default class implements DocumentFormattingEditProvider, DocumentRangeFor
       if (this.config.wxmlFormatter === 'prettier') {
         const prettier: PrettierType = requireLocalPkg(doc.uri.fsPath, 'prettier')
         const prettierOptions = await resolveOptions(prettier)
-        content = prettier.format(code, { ...this.config.prettier, ...prettierOptions })
+        content = await prettier.format(code, { ...this.config.prettier, ...prettierOptions })
       } else if (this.config.wxmlFormatter === 'jsBeautifyHtml') {
         const jsb_html = require('js-beautify').html
         let conf = this.config.jsBeautifyHtml;


### PR DESCRIPTION
**解决了什么问题**:
现在配置 `"minapp-vscode.wxmlFormatter": "prettier"` 不生效。
检查 VSCode 日志，出现了 `TypeError: u.replace is not a function` 的错误，
向上追查，是因为此插件本应返回字符串的格式化结果但却返回了一个对象，
原因就是插件里调用了 `prettier.format()`，在新版 Prettier 里此方法返回的是 promise，需要 await 才能取得字符串结果。

Prettier 的相关文档：https://prettier.io/docs/en/api#prettierformatsource-options
Prettier 中此 API 变更的 Commit：https://github.com/prettier/prettier/commit/c6d6b258331cca8fa739514557bd5b1aac67199d

**代码如何实现**:
调用 Prettier 的地方改为了 `await prettier.format()`，
不用担心这会导致旧版 Prettier 运行失败，因为 await 对于非 Promise 值会原样返回。

**检查清单**:
- [x] 本地测试通过
